### PR TITLE
Add `Serde::Serialize` for generated message types

### DIFF
--- a/easyfix-messages/easyfix-messages-gen/src/gen.rs
+++ b/easyfix-messages/easyfix-messages-gen/src/gen.rs
@@ -377,7 +377,7 @@ impl Generator {
 
             pub const BEGIN_STRING: &FixStr = unsafe { FixStr::from_ascii_unchecked(#begin_string) };
 
-            #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+            #[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Serialize)]
             #[repr(u16)]
             pub enum FieldTag {
                 #(#fields_names = #fields_numbers,)*
@@ -418,7 +418,7 @@ impl Generator {
 
             #(#structs_defs)*
 
-            #[derive(Clone, Debug)]
+            #[derive(Clone, Debug, serde::Serialize)]
             pub enum Message {
                 #(#name(#name),)*
             }
@@ -458,7 +458,7 @@ impl Generator {
 
             #(#impl_from_msg)*
 
-            #[derive(Clone, Debug)]
+            #[derive(Clone, Debug, serde::Serialize)]
             pub struct FixtMessage {
                 pub header: Box<Header>,
                 pub body: Box<Message>,

--- a/easyfix-messages/easyfix-messages-gen/src/gen.rs
+++ b/easyfix-messages/easyfix-messages-gen/src/gen.rs
@@ -390,7 +390,7 @@ impl Generator {
             }
 
             impl FieldTag {
-                const fn from_tag_num(tag_num: TagNum) -> Option<FieldTag> {
+                pub const fn from_tag_num(tag_num: TagNum) -> Option<FieldTag> {
                     match tag_num {
                         #(#fields_numbers_literals => Some(FieldTag::#fields_names),)*
                         _ => None,

--- a/easyfix-messages/easyfix-messages-gen/src/gen/enumeration.rs
+++ b/easyfix-messages/easyfix-messages-gen/src/gen/enumeration.rs
@@ -47,9 +47,9 @@ impl EnumDesc {
             quote! { match input }
         };
         let derives = if name == "MsgType" {
-            quote! { #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)] }
+            quote! { #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, serde::Serialize)] }
         } else {
-            quote! { #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)] }
+            quote! { #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, serde::Serialize)] }
         };
         quote! {
             #derives

--- a/easyfix-messages/easyfix-messages-gen/src/gen/structure.rs
+++ b/easyfix-messages/easyfix-messages-gen/src/gen/structure.rs
@@ -293,7 +293,7 @@ impl Struct {
         };
 
         quote! {
-            #[derive(Clone, Debug, Default)]
+            #[derive(Clone, Debug, Default, serde::Serialize)]
             pub struct #name {
                 #(pub #members_definitions,)*
             }

--- a/easyfix-messages/src/country.rs
+++ b/easyfix-messages/src/country.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, serde::Serialize)]
 pub enum Country {
     #[default]
     AD, // Andorra

--- a/easyfix-messages/src/currency.rs
+++ b/easyfix-messages/src/currency.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, serde::Serialize)]
 pub enum Currency {
     #[default]
     AED, // United Arab Emirates dirham


### PR DESCRIPTION
Since we already depend on serde anyway, adding serialize allows for easy dumping of messages as JSON for quick debugging, which should be nicer than staring at raw tag integers.

While at it, I made `FieldTag::from_tag_num` public, which is also quite useful for looking up tag IDs when debugging without looking it up in XML.